### PR TITLE
Add support for Bluesky social links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
 # embetter
+
+![image](https://github.com/everettsouthwick/embetter/assets/8216991/d7cbf380-39c9-4156-956d-07de961708c6)
+
 Embed better with embetter. Replaces social media links from Instagram, Threads, TikTok, Twitter, and premium editorials like The Atlantic, Bloomberg, The New York Times, Rolling Stone, The Wall Street Journal, and The Washington Post with embed-friendly alternatives on Discord.

--- a/src/commands/slash/utility/platform.js
+++ b/src/commands/slash/utility/platform.js
@@ -17,6 +17,7 @@ module.exports = {
 						{ name: 'Threads', value: 'Threads' },
 						{ name: 'TikTok', value: 'TikTok' },
 						{ name: 'Twitter', value: 'Twitter' },
+						{ name: 'Bluesky', value: 'Bluesky' },
 						{ name: 'The Atlantic', value: 'The Atlantic' },
 						{ name: 'Bloomberg', value: 'Bloomberg' },
 						{ name: 'The New York Times', value: 'The New York Times' },

--- a/src/constants/platforms.js
+++ b/src/constants/platforms.js
@@ -20,6 +20,11 @@ const platforms = [
 		replacement: (url) => url.replace('twitter.', 'vxtwitter.'),
 	},
 	{
+		name: 'Bluesky',
+		pattern: /(https?:\/\/([a-zA-Z0-9-]+\.)?bsky\.app[^?]+)/g,
+		replacement: (url) => url.replace('bsky.', 'psky.'),
+	},
+	{
 		name: 'The Atlantic',
 		pattern: /(https?:\/\/([a-zA-Z0-9-]+\.)?theatlantic\.[^?]+)/g,
 		replacement: (url) => `https://archive.today/newest/${url}`,


### PR DESCRIPTION
This PR adds support for converting bsky.app links to psky.app - I explicitly only allow the .app TLD in the regex to avoid trying to embed bsky.team, bsky.social, etc links since Bluesky does use those for other things (sometimes, like vanity handles).

This does not (yet) support converting bsky.link URLs to psky.app ones, since that would require some extra processing since the original URL gets mangled by bsky.link (to use it in a URL parameter without escaping or encoding it properly...)